### PR TITLE
Error fixing

### DIFF
--- a/lua/nuxt-dx-tools/path-aliases.lua
+++ b/lua/nuxt-dx-tools/path-aliases.lua
@@ -73,7 +73,7 @@ local function parse_tsconfig_file(filepath)
 end
 
 -- Fallback regex-based parser for when JSON parsing fails
-function parse_tsconfig_regex(content)
+parse_tsconfig_regex = function(content)
   local paths = {}
 
   -- Find the "paths" section in compilerOptions


### PR DESCRIPTION
The function was declared as local but defined as global, causing it to be nil when called from parse_tsconfig_file. Changed to properly assign to the local variable.